### PR TITLE
Add pytest to workflow dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install networkx
+          pip install networkx pytest
       - name: Run tests
         run: pytest -q


### PR DESCRIPTION
## Summary
- Install pytest alongside networkx in CI workflow to ensure tests execute

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb394a6dc8326b18dc7a0e4414378